### PR TITLE
OPS-274 Add functionality for host checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ Tiny https redirect application written in go for the sole purpose of redirectin
 | ---------------------| ------------------------- |
 | REDIRECT_HOSTNAME    | Specifies a host that will replace the host in the request when the redirect url is built. |
 | USE_HTTP             | Causes the redirect to use HTTP instead of HTTPS. Specifying anything Anything will activate this. (eg,. USE_HTTP=true) |
+| WHITELISTED_SUFFIX   | Turns on host checking to prevent host header poisioning. If enabled it will respond with the URL from REDIRECT_URL in the host header doesn't end with the string. |
+| REDIRECT_URL         | URL minus the http(s):// that will be used if a request with a host suffix that doesn't match. |
+| REDIRECT_CODE        | Code to use for the redirect. Defaults to a temporary 302 redirect. If you don't supply a valid integer it will use the default.  |
 

--- a/circle.yml
+++ b/circle.yml
@@ -8,22 +8,17 @@ dependencies:
   pre:
     - go get github.com/tools/godep
 
-
-
-#test:
-#  pre:
-#    - go vet src/redirect.go
-#
-#  override:
-#    - godep go test src/redirect/go
+test:
+  override:
+    - go test -cover
 
 deployment:
   hub:
     branch: master
     commands:
       - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build src/redirect.go
-      - docker build --tag=jdavis7257/tiny-redirect:0.2 .
+      - docker build --tag=jdavis7257/tiny-redirect:0.3 .
       - docker build --tag=jdavis7257/tiny-redirect:latest .
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push jdavis7257/tiny-redirect:0.2
+      - docker push jdavis7257/tiny-redirect:0.3
       - docker push jdavis7257/tiny-redirect:latest

--- a/src/redirect.go
+++ b/src/redirect.go
@@ -1,31 +1,62 @@
 package main
 
 import (
-	"net/http"
 	"fmt"
+	"log"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 )
 
 var redirectHost string
 var redirectHTTP bool
+var hostCheckEnabled bool
+var whiteListedSuffix string
+var redirectCode int
+var redirectURL string
 
 func main() {
 	//Handle all requests
 	http.HandleFunc("/", handle)
 	//See if the there is a redirect host so we can decide later whether or not to use it
 	redirectHost = os.Getenv("REDIRECT_HOSTNAME")
+	whiteListedSuffix = os.Getenv("WHITELISTED_SUFFIX")
+	redirectURL = os.Getenv("REDIRECT_URL")
+
+	var err error
+	if os.Getenv("REDIRECT_CODE") != "" {
+		redirectCode, err = strconv.Atoi(os.Getenv("REDIRECT_CODE"))
+	}
+	if err != nil || redirectCode == 0 {
+		redirectCode = 302
+	}
+
+	if redirectURL == "" && whiteListedSuffix != "" {
+		log.Fatal("If you specify WHITELISTED_SUFFIX you must specify REDIRECT_URL!! Please Try Again!!")
+	}
+
+	if strings.HasPrefix(redirectURL, "https://") {
+		redirectURL = strings.Replace(redirectURL, "https://", "", -1)
+	} else if strings.HasPrefix(redirectURL, "http://") {
+		redirectURL = strings.Replace(redirectURL, "http://", "", -1)
+	}
 
 	//Check to see if HTTPS should be used.
 	if os.Getenv("USE_HTTP") != "" {
 		fmt.Println("Using https for redirects.")
-		redirectHTTP = true;
+		redirectHTTP = true
 	}
 
-	if redirectHost == "" {
-		fmt.Println("Listening on port 80...\n" + "Redirect hostname was not provided. Will use host from requests to redirect")
+	if whiteListedSuffix == "" {
+		if redirectHost == "" {
+			fmt.Println("Listening on port 80...\n" + "Redirect hostname was not provided. Will use host from requests to redirect")
+		} else {
+			fmt.Println("Listening on port 80...\n" + "Redirect hostname is " + os.Getenv("REDIRECT_HOSTNAME") + ". Will use " + redirectHost + " for redirects.")
+		}
 	} else {
-		fmt.Println("Listening on port 80...\n" + "Redirect hostname is " + os.Getenv("REDIRECT_HOSTNAME") + ". Will use " + redirectHost + " for redirects.")
+		hostCheckEnabled = true
+		fmt.Println("Listening on port 80...\n" + "Whitelisted URL suffix is " + whiteListedSuffix + ". Will substitute " + redirectURL + " for un whitelisted domains.")
 	}
 
 	http.ListenAndServe(":80", nil)
@@ -34,31 +65,49 @@ func main() {
 
 func handle(w http.ResponseWriter, r *http.Request) {
 
-	var host, port string
-	//If the redirect host is empty use the host from the request
-	if redirectHost == "" {
-		host = r.Host
-	} else {
-		host = redirectHost
+	var host string
+
+	host = r.Host
+
+	//If the host contains a port then we want to remove it before continuing
+	if strings.Contains(host, ":") {
+		host = strings.Split(host, ":")[0]
 	}
 
+	// If the host check is enabled, go ahead and perform that function
+	if hostCheckEnabled {
+		if strings.HasSuffix(host, whiteListedSuffix) {
+			host = r.Host
+			redirect(w, r, host+r.RequestURI)
+		} else {
+			redirect(w, r, redirectURL)
+		}
+	} else {
+		//If the redirect host is empty use the host from the request
+		if redirectHost == "" {
+			host = r.Host
+		} else {
+			host = redirectHost
+		}
+		redirect(w, r, host+r.RequestURI)
+	}
+}
+
+func redirect(w http.ResponseWriter, r *http.Request, hostPath string) {
 	fmt.Println("Processing request from " + r.RemoteAddr)
 	path := r.RequestURI
-
 	//If some passes http as a path then slap them on the hand with a bad request.
-	if(strings.HasPrefix(path,"/http:") || strings.HasPrefix(path,"/HTTP:")|| strings.Contains(path,"comhttp")) {
+	if strings.HasPrefix(path, "/http:") || strings.HasPrefix(path, "/HTTP:") || strings.Contains(path, "comhttp") {
 		fmt.Println("Someone is trying to do something nasty. Returning 400.")
-		http.Error(w,"Bad Request",http.StatusBadRequest)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
 	} else {
 		if !redirectHTTP {
-			fmt.Println("Redirecting to https://" + host + path + " ignoring port " + port)
-			http.Redirect(w, r, "https://" + host + path, 301)
+			fmt.Println("Redirecting to https://" + hostPath)
+			http.Redirect(w, r, "https://"+hostPath, redirectCode)
 		} else {
-			fmt.Println("Redirecting to http://" + host + path + " ignoring port " + port)
-			http.Redirect(w, r, "http://" + host + path, 301)
+			fmt.Println("Redirecting to http://" + hostPath)
+			http.Redirect(w, r, "http://"+hostPath, redirectCode)
 		}
 	}
-
-
 
 }

--- a/src/redirect.go
+++ b/src/redirect.go
@@ -77,7 +77,6 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	// If the host check is enabled, go ahead and perform that function
 	if hostCheckEnabled {
 		if strings.HasSuffix(host, whiteListedSuffix) {
-			host = r.Host
 			redirect(w, r, host+r.RequestURI)
 		} else {
 			redirect(w, r, redirectURL)
@@ -94,18 +93,18 @@ func handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func redirect(w http.ResponseWriter, r *http.Request, hostPath string) {
-	fmt.Println("Processing request from " + r.RemoteAddr)
+	fmt.Println("Processing request from " + r.Host)
 	path := r.RequestURI
 	//If some passes http as a path then slap them on the hand with a bad request.
 	if strings.HasPrefix(path, "/http:") || strings.HasPrefix(path, "/HTTP:") || strings.Contains(path, "comhttp") {
-		fmt.Println("Someone is trying to do something nasty. Returning 400.")
+		log.Println("Someone is trying to do something nasty. Returning 400.")
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 	} else {
 		if !redirectHTTP {
-			fmt.Println("Redirecting to https://" + hostPath)
+			log.Println("Redirecting to https://" + hostPath)
 			http.Redirect(w, r, "https://"+hostPath, redirectCode)
 		} else {
-			fmt.Println("Redirecting to http://" + hostPath)
+			log.Println("Redirecting to http://" + hostPath)
 			http.Redirect(w, r, "http://"+hostPath, redirectCode)
 		}
 	}

--- a/src/redirect_test.go
+++ b/src/redirect_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func init() {
+	whiteListedSuffix = "test.foo"
+}
+
+func TestHandle301(t *testing.T) {
+	hostCheckEnabled = true
+
+	redirectCode = 301
+	redirectURL = "redirect.too/test"
+
+	req, err := http.NewRequest("GET", "test.foo/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execute(t, req, redirectCode, "https://"+redirectURL)
+}
+
+func TestHandle302(t *testing.T) {
+	hostCheckEnabled = true
+	whiteListedSuffix = "test.foo"
+	redirectCode = 302
+	redirectURL = "redirect.too/test"
+
+	req, err := http.NewRequest("GET", "test.foo/test1", nil)
+	req.RequestURI = "/test1"
+	req.Host = "test.foo"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execute(t, req, redirectCode, "https://"+"test.foo/test1")
+}
+
+func TestHandleBadHost(t *testing.T) {
+	hostCheckEnabled = true
+	redirectCode = 302
+	redirectURL = "redirect.too/test"
+
+	req, err := http.NewRequest("GET", "http://test.wrong/test", nil)
+	req.URL = &url.URL{
+		Scheme: "http",
+		Host:   "test.wrong",
+	}
+
+	req.Header.Set("Host", "test.wrong")
+	req.Host = "test.wrong"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execute(t, req, redirectCode, "https://"+redirectURL)
+}
+
+func TestHandleBadHostHttp(t *testing.T) {
+	hostCheckEnabled = true
+	redirectCode = 302
+	redirectURL = "redirect.too/test"
+	redirectHTTP = true
+	req, err := http.NewRequest("GET", "http://test.wrong/test", nil)
+	req.URL = &url.URL{
+		Scheme: "http",
+		Host:   "test.wrong",
+	}
+
+	req.Header.Set("Host", "test.wrong")
+	req.Host = "test.wrong"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execute(t, req, redirectCode, "http://"+redirectURL)
+
+	redirectHTTP = false
+}
+
+func TestHttp(t *testing.T) {
+	hostCheckEnabled = true
+	redirectCode = 302
+	redirectURL = "redirect.too/test"
+	redirectHTTP = true
+
+	req, err := http.NewRequest("GET", "test.foo/test1", nil)
+	req.RequestURI = "/test1"
+	req.Host = "test.foo"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	execute(t, req, redirectCode, "http://"+"test.foo/test1")
+	redirectHTTP = false
+
+}
+
+func execute(t *testing.T, req *http.Request, expectedCode int, expectedLocation string) {
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(handle)
+
+	handler.ServeHTTP(rr, req)
+
+	assertEqual(t, rr.Code, expectedCode, "Redirect Code Incorrect")
+	assertEqual(t, rr.Header().Get("Location"), expectedLocation, "Location was incorrect.")
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}, message string) {
+	if a == b {
+		return
+	}
+	if len(message) == 0 {
+		message = fmt.Sprintf("%v != %v", a, b)
+	}
+	t.Fatal(message)
+}


### PR DESCRIPTION
Added configurations for host header checking before performing a redirect with the ability to override it if neccessary. 